### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -19,17 +19,17 @@ Sim800L	KEYWORD1
 
 # Methods for calling (KEYWORD2)
 #######################################
-answerCall KEYWORD2
-callNumber KEYWORD2
-hangoffCall KEYWORD2
+answerCall	KEYWORD2
+callNumber	KEYWORD2
+hangoffCall	KEYWORD2
 
 
 # Methods for Sms (KEYWORD2)
 #######################################
 sendSms	KEYWORD2
-readSms KEYWORD2 
-delAllSms KEYWORD2
-getNumberSms KEYWORD2
+readSms	KEYWORD2 
+delAllSms	KEYWORD2
+getNumberSms	KEYWORD2
 
 # Methods for Module (KEYWORD2)
 #######################################


### PR DESCRIPTION
The Arduino IDE requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords