### PR TITLE
Waiting for CMGS when sending the message

### DIFF
--- a/Sim800L.cpp
+++ b/Sim800L.cpp
@@ -481,11 +481,13 @@ bool Sim800L::sendSms(char* number,char* text)
     this->SoftwareSerial::print((char)26);
     _buffer=_readSerial(60000);
     //expect CMGS:xxx   , where xxx is a number,for the sending sms.
-    if ( (_buffer.indexOf("ER")) == -1)
-    {
+    if ((_buffer.indexOf("ER")) != -1) {
+        return true;
+    } else if ((_buffer.indexOf("CMGS")) != -1) {
         return false;
-    }
-    else return true;
+  	} else {
+    	return true;
+  	}
     // Error found, return 1
     // Error NOT found, return 0
 }


### PR DESCRIPTION
I was getting false positives when sending the message right on the reboot without an active signal.

Return string from the module was: +CSN:1 OK, which was interpreted as a success.

How to reproduce:
1. power on arduino after it was without power for long time (long enough to loose connection)
1. try to send a message in the start of the loop or in setup
1. sendSms will return false, but it should actually be true (it was not an error, but it was definitely not a success)